### PR TITLE
Add eigen replacement for matrix power rebuild

### DIFF
--- a/Code/R/Development/SlimPosition/DESCRIPTION
+++ b/Code/R/Development/SlimPosition/DESCRIPTION
@@ -9,3 +9,7 @@ Description: More about what it does (maybe more than one line)
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true
+Imports: Rcpp (>= 0.12.12),
+	 RcppEigen
+LinkingTo: Rcpp,
+	   RcppEigen

--- a/Code/R/Development/SlimPosition/NAMESPACE
+++ b/Code/R/Development/SlimPosition/NAMESPACE
@@ -1,1 +1,3 @@
 exportPattern("^[[:alpha:]]+")
+importFrom(Rcpp, evalCpp)
+useDynLib(SlimPosition)

--- a/Code/R/Development/SlimPosition/src/gsvd_eigen.cpp
+++ b/Code/R/Development/SlimPosition/src/gsvd_eigen.cpp
@@ -1,0 +1,65 @@
+#include <RcppEigen.h>
+// [[Rcpp::depends(RcppEigen)]]
+
+using namespace Rcpp ;
+using namespace Eigen ;
+
+void destructive_threshold_matrix(MatrixXd& m, double tol){
+  for(int i = 0; i < m.rows(); ++i)
+    for(int j = 0; j < m.cols(); ++j)
+      if(abs(m(i,j)) < tol)
+	m(i,j) = 0;
+}
+
+// [[Rcpp::export]]
+MatrixXd matrix_power(MatrixXd m, double power, double tol, int k){
+  int n = m.rows();
+  int p = m.cols();
+  BDCSVD<MatrixXd> solver(m, ComputeThinU | ComputeThinV);
+  //JacobiSVD<MatrixXd> solver(m, ComputeThinU | ComputeThinV);
+  
+  MatrixXd u = solver.matrixU();
+  MatrixXd v = solver.matrixV();
+  VectorXd d = solver.singularValues();
+
+  //Compute the rank given tolerance
+  int rank = 0;
+  for(int i = 0; i < d.size(); ++i){
+    if(d(i) * d(i) <  tol) break;
+    ++rank;
+  }
+
+  // Rcout << u.rows() << " " << solver.matrixU().cols() << '\n';
+  // Rcout << v.rows() << " " << v.cols() << '\n';
+  // Rcout << rank << '\n';
+  // Rcout << d.head(10) << "\n";
+
+  if(k < rank)
+    rank = k;
+  
+  MatrixXd lru = u.block(0,0,n,rank);
+  MatrixXd lrv = v.block(0,0,p,rank);
+  VectorXd lrd = d.head(rank);
+
+  if(!lrd.allFinite())
+    stop("Matrix is not diagonalizable, maybe try centering/scaling");
+
+  // Zero lru and lrv when small (probably not necessary, but quick)
+  destructive_threshold_matrix(lru, tol);
+  destructive_threshold_matrix(lrv, tol);
+
+  // Exponentiate singular values
+  for(int j = 0; j < rank; ++j)
+    lrd(j) = pow(lrd(j), power);
+
+
+  // Multiply exponentiated singular values back in
+  for(int j = 0; j < rank; ++j)
+    for(int i = 0; i < n; ++i)
+      lru(i,j) *= lrd(j);
+
+  MatrixXd res = lru * lrv.transpose();
+  destructive_threshold_matrix(res, tol);
+
+  return(res);
+}


### PR DESCRIPTION
Adds an RcppEigen replacement for `matrix.power.rebuild`, testing ~2x faster on some benchmark, first steps to an eigen implementation of your GSVD.

Benchmarks -

Small:
```
> sourceCpp("./gsvd_eigen.cpp")
> n <- 1000
> p <- 100
> m <- matrix(runif(n*p), nrow = n, ncol = p)
> system.time(md <- power.rebuild_matrix(m, .77))
   user  system elapsed 
  0.036   0.000   0.036 
> system.time(mc <- matrix_power(m, .77, tol = .Machine$double.eps, k = p))
   user  system elapsed 
  0.020   0.000   0.019 
> all.equal(md, mc)
[1] TRUE
```

Medium:
```
> n <- 5000
> p <- 1000
> m <- matrix(runif(n*p), nrow = n, ncol = p)
> system.time(md <- power.rebuild_matrix(m, .77))
   user  system elapsed 
 17.912   0.036  17.950 
> system.time(mc <- matrix_power(m, .77, tol = .Machine$double.eps, k = p))
   user  system elapsed 
  7.780   0.028   7.811 
> all.equal(md, mc)
[1] TRUE
```

Large(ish):
```
> n <- 10000
> p <- 1000
> m <- matrix(runif(n*p), nrow = n, ncol = p)
> system.time(md <- power.rebuild_matrix(m, .77))
   user  system elapsed 
 35.324   0.076  35.401 
> system.time(mc <- matrix_power(m, .77, tol = .Machine$double.eps, k = p))
   user  system elapsed 
 15.828   0.048  15.877
 > all.equal(md, mc)
[1] TRUE
```